### PR TITLE
Use https against ViaNett

### DIFF
--- a/src/Vianett/VianettHttpRequest.php
+++ b/src/Vianett/VianettHttpRequest.php
@@ -12,7 +12,7 @@ class VianettHttpRequest {
   /**
    *
    */
-  const HOST = 'http://smsc.vianett.no/V3/CPA/MT/MT.ashx';
+  const HOST = 'https://smsc.vianett.no/V3/CPA/MT/MT.ashx';
 
   public function setValues($values = []) {
     $this->values = $values;


### PR DESCRIPTION
Laravel already requires the openssl package, so I can't see any reason for not using https against ViaNett.