### PR TITLE
Move to the recommended package of php-coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ script:
 after_success:
   #- travis_retry php vendor/bin/coveralls
   # or enable logging
-  - travis_retry php vendor/bin/coveralls -v
+  - travis_retry php vendor/bin/php-coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   "require-dev": {
     "phpunit/phpunit": "^5.0",
     "jakub-onderka/php-parallel-lint": "0.9",
-    "satooshi/php-coveralls": "dev-master"
+    "php-coveralls/php-coveralls": "^2.0"
   },
   "scripts": {
     "test": [


### PR DESCRIPTION
When trying to install this project, it fails because it requires dev-master of satooshi/php-coveralls. Which is not a thing anymore (there is no master branch).

In addition, that package is abanded for php-coveralls/php-coveralls.

PR to fix it